### PR TITLE
[FEAT] UT용 테스트플라이트 HomeView 디자인 조정

### DIFF
--- a/GMG.xcodeproj/project.pbxproj
+++ b/GMG.xcodeproj/project.pbxproj
@@ -28,7 +28,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		E3BD259E2EA4E13900FB6CFD /* Exceptions for "GMG" folder in "GMG" target */ = {
+		32071CE72EBF162F00F03308 /* Exceptions for "GMG" folder in "GMG" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -41,7 +41,7 @@
 		32C5AB532EA213420007BEFD /* GMG */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
-				E3BD259E2EA4E13900FB6CFD /* Exceptions for "GMG" folder in "GMG" target */,
+				32071CE72EBF162F00F03308 /* Exceptions for "GMG" folder in "GMG" target */,
 			);
 			path = GMG;
 			sourceTree = "<group>";

--- a/GMG/Scenes/Home/HomeView.swift
+++ b/GMG/Scenes/Home/HomeView.swift
@@ -122,7 +122,7 @@ struct HomeView: View {
                                 size: 42
                             )
 
-                            VStack(alignment: .leading) {
+                            VStack(alignment: .leading, spacing: 8) {
                                 Text("An experience")
                                     .font(font)
                                     .foregroundStyle(Color.white3.opacity(0.6))

--- a/GMG/Scenes/Home/HomeView.swift
+++ b/GMG/Scenes/Home/HomeView.swift
@@ -181,7 +181,7 @@ extension HomeView {
         @State private var isEditable: Bool = false
         @FocusState private var isTitleFocused: Bool
         
-        // ✅ 로컬 편집 버퍼
+        // 로컬 편집 버퍼
         @State private var tempTitle: String = ""
         
         let score: Score
@@ -196,25 +196,22 @@ extension HomeView {
         var body: some View {
             HStack {
                 VStack(alignment: .leading, spacing: .zero) {
-                    
-                    // ✅ 제목 영역
                     if isEditable {
                         TextField("", text: $tempTitle)
                             .font(Typography.WantedSansStd.R4)
                             .foregroundStyle(Color.white1)
                             .focused($isTitleFocused)
                             .onAppear {
-                                // 편집 시작 시 현재 저장된 타이틀을 버퍼로 복사
                                 tempTitle = score.title
                                 DispatchQueue.main.async {
                                     isTitleFocused = true
                                 }
                             }
-                            .onSubmit { endRename(commit: true) }   // 엔터로 커밋
+                            .onSubmit { endRename(commit: true) }
                             .submitLabel(.done)
                             .padding(.bottom, 4)
                     } else {
-                        Text(score.title) // ✅ 항상 저장된 값 표시
+                        Text(score.title)
                             .font(Typography.WantedSansStd.R4)
                             .foregroundStyle(Color.white1)
                             .padding(.bottom, 4)
@@ -234,11 +231,9 @@ extension HomeView {
                 
                 Spacer()
                 
-                // 우측 액션들
                 VStack(alignment: .trailing, spacing: .zero) {
                     
                     Menu {
-                        // ✅ Rename: 편집 시작 + 포커스
                         Button {
                             startRename()
                         } label: {
@@ -316,7 +311,7 @@ extension HomeView {
             .contentShape(RoundedRectangle(cornerRadius: 32))
             .onTapGesture {
                 if isEditable {
-                    endRename(commit: true) // ✅ 바깥 탭으로 커밋 & 종료
+                    endRename(commit: true)
                 } else {
                     if isSelected {
                         action()
@@ -343,7 +338,6 @@ extension HomeView {
                 // 빈 문자열로 저장되는 것 방지 + 변경 시에만 저장
                 if !new.isEmpty, new != score.title {
                     score.title = new
-                    // SwiftData는 자동 저장되지만, 즉시 반영 원하면 강제 저장 가능
                     try? modelContext.save()
                 }
             }
@@ -432,7 +426,7 @@ extension HomeView {
     }
     
     static func formatDuration(_ seconds: Double) -> String {
-        let totalSeconds = Int(seconds.rounded())  // 반올림해서 Int로 변환
+        let totalSeconds = Int(seconds.rounded())
         let minutes = totalSeconds / 60
         let seconds = totalSeconds % 60
         return String(format: "%02d:%02d", minutes, seconds)
@@ -452,6 +446,6 @@ extension HomeView {
     }
 }
 
-//#Preview(traits: .routerModifier) {
-//    HomeView()
-//}
+#Preview(traits: .routerModifier) {
+    HomeView()
+}

--- a/GMG/Scenes/Home/HomeView.swift
+++ b/GMG/Scenes/Home/HomeView.swift
@@ -282,8 +282,7 @@ extension HomeView {
                     
                     Spacer()
                     
-                    Text(score.totalDuration.description)
-                        .font(Typography.WantedSansStd.R2)
+                    Text(HomeView.formatDuration(score.totalDuration))                        .font(Typography.WantedSansStd.R2)
                         .foregroundStyle(Color.white1)
                         .padding(.bottom, 9.5)
                         .padding(.trailing, 1)
@@ -431,7 +430,14 @@ extension HomeView {
         formatted.dateFormat = "yy. MM. dd"
         return formatted.string(from: date)
     }
-
+    
+    static func formatDuration(_ seconds: Double) -> String {
+        let totalSeconds = Int(seconds.rounded())  // 반올림해서 Int로 변환
+        let minutes = totalSeconds / 60
+        let seconds = totalSeconds % 60
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+    
     private func bindingForAll(index i: Int) -> Binding<Bool> {
         Binding(
             get: { expandedAll == i },

--- a/GMG/Scenes/Home/HomeView.swift
+++ b/GMG/Scenes/Home/HomeView.swift
@@ -67,7 +67,7 @@ struct HomeView: View {
                                 )
                                 
                                 ForEach(
-                                    Array(recentScores.enumerated()),
+                                    Array(recentScores.prefix(3).enumerated()),
                                     id: \.element.persistentModelID
                                 ) { (idx, score) in
                                     ScoreCard(

--- a/GMG/Scenes/Home/HomeView.swift
+++ b/GMG/Scenes/Home/HomeView.swift
@@ -11,6 +11,7 @@ struct HomeView: View {
 
     @State private var expandedAll: Int? = nil
     @State private var isLatest: Bool = true
+    @State private var showActions = false
 
     private var songCount: Int { allScores.count }
 
@@ -123,16 +124,16 @@ struct HomeView: View {
                             VStack(alignment: .leading) {
                                 Text("An experience")
                                     .font(font)
-                                    .foregroundStyle(Color.black1.opacity(0.1))
+                                    .foregroundStyle(Color.white3.opacity(0.6))
                                 Text("where humming")
                                     .font(font)
-                                    .foregroundStyle(Color.black1.opacity(0.3))
+                                    .foregroundStyle(Color.black8.opacity(0.4))
                                 Text("becomes the")
                                     .font(font)
-                                    .foregroundStyle(Color.black1.opacity(0.5))
+                                    .foregroundStyle(Color.black4.opacity(0.4))
                                 Text("start of a song")
                                     .font(font)
-                                    .foregroundStyle(Color.black1.opacity(0.6))
+                                    .foregroundStyle(Color.black4.opacity(0.55))
                             }
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.top, 48)
@@ -171,6 +172,8 @@ struct HomeView: View {
 
 extension HomeView {
     struct ScoreCard: View {
+        @State private var showActions = false
+        
         let score: Score
         let minWidth: CGFloat?
         let minHeight: CGFloat?
@@ -192,25 +195,57 @@ extension HomeView {
                         .foregroundStyle(Color.white1)
 
                     Spacer()
-
+                    
                     Text(HomeView.dateConverter(score.createdAt))
                         .font(Typography.WantedSansStd.R2)
                         .foregroundStyle(Color.black6)
                 }
-
+                
                 Spacer()
-
+                
                 VStack(alignment: .trailing, spacing: .zero) {
-                    Button(
-                        action: {
-                            //TODO: 미트볼버튼 기능 추가
-                        },
-                        label: {
-                            Image(systemName: "ellipsis")
-                                .foregroundStyle(Color.white1)
+                    
+                    Menu {
+                        Button {
+                            // TODO: Rename
+                        } label: {
+                            HStack(spacing: 14) {
+                                Image(systemName: "pencil")
+                                    .foregroundStyle(Color.black1)
+                                Text("Rename")
+                                    .font(Typography.WantedSansStd.R3)
+                                    .foregroundStyle(Color.black1)
+                            }
                         }
-                    )
-                    .buttonStyle(.plain)
+
+                        Button {
+                            // TODO: Export
+                        } label: {
+                            HStack(spacing: 14) {
+                                Image(systemName: "square.and.arrow.up")
+                                    .foregroundStyle(Color.black1)
+                                Text("Export")
+                                    .font(Typography.WantedSansStd.R3)
+                                    .foregroundStyle(Color.black1)
+                            }
+                        }
+
+                        Button {
+                            // TODO: Delete
+                        } label: {
+                            HStack(spacing: 14) {
+                                Image(systemName: "trash")
+                                    .foregroundStyle(Color.blue2)
+                                Text("Delete")
+                                    .font(Typography.WantedSansStd.R3)
+                                    .foregroundStyle(Color.blue2)
+                            }
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis")
+                            .foregroundStyle(Color.white1)
+                    }
+                    .menuIndicator(.hidden)
 
                     Spacer()
 
@@ -286,7 +321,7 @@ extension HomeView {
                         in: RoundedRectangle(cornerRadius: 18)
                     )
             }
-            .frame(width: songCount==0 ? 80 : 128)
+            .frame(width: songCount == 0 ? 156 : 77)
         }
     }
 
@@ -355,6 +390,6 @@ extension HomeView {
     }
 }
 
-#Preview(traits: .routerModifier) {
-    HomeView()
-}
+//#Preview(traits: .routerModifier) {
+//    HomeView()
+//}

--- a/GMG/Scenes/Home/HomeView.swift
+++ b/GMG/Scenes/Home/HomeView.swift
@@ -172,7 +172,12 @@ struct HomeView: View {
 
 extension HomeView {
     struct ScoreCard: View {
+        @Environment(\.modelContext) private var modelContext
+        @Environment(Router.self) private var router: Router
         @State private var showActions = false
+        @State private var isRenaming = false
+        @State private var editableTitle = ""
+        @FocusState private var titleFocused: Bool
         
         let score: Score
         let minWidth: CGFloat?
@@ -219,7 +224,9 @@ extension HomeView {
                         }
 
                         Button {
-                            // TODO: Export
+                            router.push(
+                                .export
+                            )
                         } label: {
                             HStack(spacing: 14) {
                                 Image(systemName: "square.and.arrow.up")
@@ -231,7 +238,7 @@ extension HomeView {
                         }
 
                         Button {
-                            // TODO: Delete
+                            modelContext.delete(score)
                         } label: {
                             HStack(spacing: 14) {
                                 Image(systemName: "trash")

--- a/GMG/Scenes/Home/HomeView.swift
+++ b/GMG/Scenes/Home/HomeView.swift
@@ -73,7 +73,8 @@ struct HomeView: View {
                                 ) { (idx, score) in
                                     ScoreCard(
                                         score: score,
-                                        minWidth: 160,
+                                        minWidth: 156,
+                                        maxWidth: 156,
                                         minHeight: nil,
                                         index: idx + 1,
                                         isMove: false,
@@ -147,6 +148,7 @@ struct HomeView: View {
                                     ScoreCard(
                                         score: score,
                                         minWidth: nil,
+                                        maxWidth: nil,
                                         minHeight: 128,
                                         index: idx + 1,
                                         isMove: true,
@@ -174,31 +176,55 @@ extension HomeView {
     struct ScoreCard: View {
         @Environment(\.modelContext) private var modelContext
         @Environment(Router.self) private var router: Router
+        
         @State private var showActions = false
-        @State private var isRenaming = false
-        @State private var editableTitle = ""
-        @FocusState private var titleFocused: Bool
+        @State private var isEditable: Bool = false
+        @FocusState private var isTitleFocused: Bool
+        
+        // ✅ 로컬 편집 버퍼
+        @State private var tempTitle: String = ""
         
         let score: Score
         let minWidth: CGFloat?
+        let maxWidth: CGFloat?
         let minHeight: CGFloat?
         let index: Int
         let isMove: Bool
         @Binding var isSelected: Bool
         let action: () -> Void
-
+        
         var body: some View {
             HStack {
                 VStack(alignment: .leading, spacing: .zero) {
-                    Text(score.title)
-                        .font(Typography.WantedSansStd.R4)
-                        .foregroundStyle(Color.white1)
-                        .padding(.bottom, 4)
-
+                    
+                    // ✅ 제목 영역
+                    if isEditable {
+                        TextField("", text: $tempTitle)
+                            .font(Typography.WantedSansStd.R4)
+                            .foregroundStyle(Color.white1)
+                            .focused($isTitleFocused)
+                            .onAppear {
+                                // 편집 시작 시 현재 저장된 타이틀을 버퍼로 복사
+                                tempTitle = score.title
+                                DispatchQueue.main.async {
+                                    isTitleFocused = true
+                                }
+                            }
+                            .onSubmit { endRename(commit: true) }   // 엔터로 커밋
+                            .submitLabel(.done)
+                            .padding(.bottom, 4)
+                    } else {
+                        Text(score.title) // ✅ 항상 저장된 값 표시
+                            .font(Typography.WantedSansStd.R4)
+                            .foregroundStyle(Color.white1)
+                            .padding(.bottom, 4)
+                            .lineLimit(1)
+                    }
+                    
                     Text("\(score.key.description) Key")
                         .font(Typography.WantedSansStd.R2)
                         .foregroundStyle(Color.white1)
-
+                    
                     Spacer()
                     
                     Text(HomeView.dateConverter(score.createdAt))
@@ -208,11 +234,13 @@ extension HomeView {
                 
                 Spacer()
                 
+                // 우측 액션들
                 VStack(alignment: .trailing, spacing: .zero) {
                     
                     Menu {
+                        // ✅ Rename: 편집 시작 + 포커스
                         Button {
-                            // TODO: Rename
+                            startRename()
                         } label: {
                             HStack(spacing: 14) {
                                 Image(systemName: "pencil")
@@ -222,11 +250,9 @@ extension HomeView {
                                     .foregroundStyle(Color.black1)
                             }
                         }
-
+                        
                         Button {
-                            router.push(
-                                .export
-                            )
+                            router.push(.export)
                         } label: {
                             HStack(spacing: 14) {
                                 Image(systemName: "square.and.arrow.up")
@@ -236,7 +262,7 @@ extension HomeView {
                                     .foregroundStyle(Color.black1)
                             }
                         }
-
+                        
                         Button {
                             modelContext.delete(score)
                         } label: {
@@ -253,15 +279,15 @@ extension HomeView {
                             .foregroundStyle(Color.white1)
                     }
                     .menuIndicator(.hidden)
-
+                    
                     Spacer()
-
+                    
                     Text(score.totalDuration.description)
                         .font(Typography.WantedSansStd.R2)
                         .foregroundStyle(Color.white1)
                         .padding(.bottom, 9.5)
                         .padding(.trailing, 1)
-
+                    
                     Button {
                         // TODO: 오디오 재생 기능
                     } label: {
@@ -280,7 +306,7 @@ extension HomeView {
             .padding(Spacing.lg)
             .frame(
                 minWidth: minWidth,
-                maxWidth: .infinity,
+                maxWidth: maxWidth,
                 minHeight: minHeight,
                 maxHeight: .infinity
             )
@@ -290,32 +316,55 @@ extension HomeView {
             )
             .contentShape(RoundedRectangle(cornerRadius: 32))
             .onTapGesture {
-                if isSelected {
-                    action()
+                if isEditable {
+                    endRename(commit: true) // ✅ 바깥 탭으로 커밋 & 종료
                 } else {
-                    isSelected.toggle()
+                    if isSelected {
+                        action()
+                    } else {
+                        isSelected.toggle()
+                    }
                 }
             }
             .padding(.bottom, isSelected && isMove ? 60 : 0)
         }
-
+        
+        // MARK: - Rename Helpers
+        private func startRename() {
+            tempTitle = score.title
+            isEditable = true
+            DispatchQueue.main.async {
+                isTitleFocused = true
+            }
+        }
+        
+        private func endRename(commit: Bool) {
+            if commit {
+                let new = tempTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+                // 빈 문자열로 저장되는 것 방지 + 변경 시에만 저장
+                if !new.isEmpty, new != score.title {
+                    score.title = new
+                    // SwiftData는 자동 저장되지만, 즉시 반영 원하면 강제 저장 가능
+                    try? modelContext.save()
+                }
+            }
+            isTitleFocused = false
+            isEditable = false
+        }
+        
         private func colorForIndex(_ i: Int) -> Color {
             let palette: [Color] = [
-                Color.blue3,
-                Color.blue4,
-                Color.blue5,
-                Color.blue1,
-                Color.blue2,
+                Color.blue3, Color.blue4, Color.blue5, Color.blue1, Color.blue2,
             ]
             let safe = max(i, 1)
             return palette[(safe - 1) % palette.count]
         }
     }
-
+    
     struct AddScoreButton: View {
         let action: () -> Void
         let songCount: Int
-
+        
         var body: some View {
             Button {
                 action()

--- a/GMG/Scenes/Home/HomeView.swift
+++ b/GMG/Scenes/Home/HomeView.swift
@@ -56,13 +56,16 @@ struct HomeView: View {
                                 .foregroundStyle(Color.black1)
                             Spacer()
                         }
-
+                        
                         ScrollView(.horizontal, showsIndicators: false) {
                             LazyHStack(spacing: Spacing.md) {
-                                AddScoreButton {
-                                    router.push(.recording)
-                                }
-
+                                AddScoreButton (
+                                    action: {
+                                        router.push(.recording)
+                                    },
+                                    songCount: songCount
+                                )
+                                
                                 ForEach(
                                     Array(recentScores.enumerated()),
                                     id: \.element.persistentModelID
@@ -269,6 +272,7 @@ extension HomeView {
 
     struct AddScoreButton: View {
         let action: () -> Void
+        let songCount: Int
 
         var body: some View {
             Button {
@@ -282,7 +286,7 @@ extension HomeView {
                         in: RoundedRectangle(cornerRadius: 18)
                     )
             }
-            .frame(width: 80)
+            .frame(width: songCount==0 ? 80 : 128)
         }
     }
 


### PR DESCRIPTION
### 1. 🚀 어떤 종류의 PR인가요? (What type of PR is this?)
- [ ] **Bug**: 예상과 다르게 동작하는 문제 또는 버그를 수정합니다.
- [ ] **Chore**: 빌드, 설정, 라이브러리 업데이트 등 사용자에게 직접적인 영향이 없는 작업을 합니다.
- [ ] **Documentation**: 문서(README, Wiki, API 문서 등)를 추가하거나 수정합니다.
- [x] **Feature**: 새로운 기능을 추가합니다.
- [ ] **Refactor**: 버그 수정이나 기능 추가 없이 기존 코드를 개선합니다.
- [ ] **Style**: 코드 포맷팅, 세미콜론 누락 등 코드 스타일에 관련된 것을 수정합니다.
- [ ] **Test**: 테스트 코드를 추가하거나 수정합니다.


### 2. 📝 개요 (Description)
➡️ *가이드: PR의 목적을 한두 문장으로 요약합니다. '무엇을' & '왜' 수정했는지 리뷰어가 쉽게 이해할 수 있도록 작성하는 것이 핵심입니다.*
UT용으로 디자이너 측에서 홈뷰에 요청한 디자인 변경 사항을 반영 후 테스트플라이트 배포를 위한 PR입니다.


### 3. 🔗 관련 이슈 (Related Issue)
➡️ *가이드: 관련된 이슈 번호를 `Closes #이슈번호` 형식으로 적어주세요. 이렇게 하면 PR이 머지될 때 해당 이슈가 자동으로 종료되어 편리합니다.*
Closes #26 


### 4. ✅ 작업 목록 (Checklist)
➡️ *가이드: 리뷰어가 코드 변경 사항을 쉽게 따라갈 수 있도록, 실제 작업 내역을 구체적인 단위로 나누어 나열합니다.*
- 저장된 노래가 없을 때의 AddScore 버튼의 크기를 조정했습니다.
- 저장된 노래가 없을 때의 EmptyText의 색상, Padding값을 조절했습니다.
- Recent File에 표시되는 곡 갯수를 3개로 제한했습니다.
- ScoreCard의 ...버튼을 눌렀을 때 표시되는 Popover 버튼을 구현했습니다.
- Popover 버튼의 Rename, Export, Delete 기능을 구현했습니다.
- 녹음된 시간이 30.12, 21.32 등으로 표시되는 오류를 정제 함수를 구현해 00:30, 00:21 등 MM:SS의 형태로 구성되도록 조정했습니다.


### 5. 📸 스크린샷 (Screenshots)
➡️ *가이드: UI 변경이 있다면, 수정 전(Before)과 후(After)의 모습을 스크린샷으로 첨부하여 리뷰어가 직관적으로 변화를 이해하도록 돕습니다.*
|<img width="278" height="587" alt="스크린샷 2025-11-09 오전 2 28 15" src="https://github.com/user-attachments/assets/fd04933e-7f97-4601-a95f-2b02f7591def" />|<img width="278" height="587" alt="IMG_3388" src="https://github.com/user-attachments/assets/ba714c49-49bf-45b9-b9b4-af23faf64eb3" />|<img width="278" height="587" alt="IMG_3389" src="https://github.com/user-attachments/assets/51cf00fa-4bc8-45ae-8865-8d4ee8b10ec4" />|


### 6. ❗ 리뷰어에게 전달할 기타 사항 (Other information for reviewers)
➡️ *가이드: 리뷰어가 놓치지 않고 꼭 확인해야 할 핵심 코드 위치나, 특정 방식으로 테스트가 필요한 경우 친절하게 안내합니다. 리뷰 효율을 크게 높일 수 있습니다.*
- 현재 해당 PR의 경우 MVI 형태로 분리되어 있지 않습니다. 해당 PR은 외부 테스트플라이트 배포를 위해 디자인 수정, 녹음 소리 증가를 목적으로 만들어진 테플로 추후 #20 에서 분리 후 다시 커밋할 예정입니다.
