### PR TITLE
[bug] 스와이프 제스처로 이전 화면으로 네비게이션할 수 없는 문제 수정

### DIFF
--- a/GMG/Core/Utils/UINavigationController+Extensions.swift
+++ b/GMG/Core/Utils/UINavigationController+Extensions.swift
@@ -1,0 +1,15 @@
+//  Copyright © 2025 ADA 4th GMG. All rights reserved.
+
+import SwiftUI
+
+/// Hide navigation bar without losing swipe back gesture
+extension UINavigationController: @retroactive UIGestureRecognizerDelegate {
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = self
+    }
+
+    public func gestureRecognizerShouldBegin(_: UIGestureRecognizer) -> Bool {
+        return viewControllers.count > 1
+    }
+}


### PR DESCRIPTION
### 설명

스와이프 제스처로 이전 화면으로 네비게이션할 수 없는 문제 수정

### 관련 이슈

Closes #37

### 작업 내용

- [x] UINavigationController 코드 추가

### 스크린샷 (Optional)



### 참고 내용

`.toolbarVisibility(.hidden, for: .navigationBar)`으로 네비게이션바를 숨길 경우 스와이프 제스처가 작동하지 않는 문제 수정했습니다.