### PR TITLE
[bug] 앱 업데이트 시 오디오 파일을 찾을 수 없는 문제 수정

### DIFF
--- a/GMG/Core/Models/Score/Score.swift
+++ b/GMG/Core/Models/Score/Score.swift
@@ -2,13 +2,18 @@
 
 import Foundation
 import SwiftData
+internal import UniformTypeIdentifiers
 
 @Model
 class Score {
     var id: UUID = UUID()
     var title: String
     var key: Key
-    var audioUrl: URL
+    var audioFileName: String
+    var audioUrl: URL {
+        return Self.recordingFolder
+            .appending(component: audioFileName)
+    }
     var totalDuration: TimeInterval
     var createdAt: Date
     var updatedAt: Date
@@ -18,7 +23,7 @@ class Score {
     init(
         title: String,
         key: Key,
-        audioUrl: URL,
+        audioFileName: String,
         totalDuration: TimeInterval,
         createdAt: Date,
         updatedAt: Date,
@@ -27,7 +32,7 @@ class Score {
     ) {
         self.title = title
         self.key = key
-        self.audioUrl = audioUrl
+        self.audioFileName = audioFileName
         self.totalDuration = totalDuration
         self.createdAt = createdAt
         self.updatedAt = updatedAt
@@ -87,7 +92,7 @@ extension Score {
         Score(
             title: "Untitled",
             key: Key(root: .C),
-            audioUrl: Bundle.main.bundleURL,
+            audioFileName: "Untitled.m4a",
             totalDuration: 31.0,
             createdAt: Date(),
             updatedAt: Date(),
@@ -95,30 +100,55 @@ extension Score {
             chordCells: [
                 ChordCell(
                     chord: Chord(root: .C, quality: .maj),
-                    chordCandidates: [Chord(root: .C, quality: .maj), Chord(root: .D, quality: .maj), Chord(root: .Ab, quality: .maj), Chord(root: .Gb, quality: .maj), Chord(root: .Eb, quality: .maj)],
+                    chordCandidates: [
+                        Chord(root: .C, quality: .maj), Chord(root: .D, quality: .maj),
+                        Chord(root: .Ab, quality: .maj), Chord(root: .Gb, quality: .maj),
+                        Chord(root: .Eb, quality: .maj),
+                    ],
                     startTime: 0.0
                 ),
                 ChordCell(
                     chord: Chord(root: .D, quality: .min),
-                    chordCandidates: [Chord(root: .D, quality: .min), Chord(root: .D, quality: .maj), Chord(root: .Ab, quality: .maj), Chord(root: .Gb, quality: .maj), Chord(root: .Eb, quality: .maj)],
+                    chordCandidates: [
+                        Chord(root: .D, quality: .min), Chord(root: .D, quality: .maj),
+                        Chord(root: .Ab, quality: .maj), Chord(root: .Gb, quality: .maj),
+                        Chord(root: .Eb, quality: .maj),
+                    ],
                     startTime: 2.5
                 ),
                 ChordCell(
                     chord: Chord(root: .E, quality: .dim),
-                    chordCandidates: [Chord(root: .E, quality: .dim), Chord(root: .D, quality: .maj), Chord(root: .Ab, quality: .maj), Chord(root: .Gb, quality: .maj), Chord(root: .Eb, quality: .maj)],
+                    chordCandidates: [
+                        Chord(root: .E, quality: .dim), Chord(root: .D, quality: .maj),
+                        Chord(root: .Ab, quality: .maj), Chord(root: .Gb, quality: .maj),
+                        Chord(root: .Eb, quality: .maj),
+                    ],
                     startTime: 5.0
                 ),
                 ChordCell(
                     chord: Chord(root: .F, quality: .maj9),
-                    chordCandidates: [Chord(root: .F, quality: .maj9), Chord(root: .D, quality: .maj), Chord(root: .Ab, quality: .maj), Chord(root: .Gb, quality: .maj), Chord(root: .Eb, quality: .maj)],
+                    chordCandidates: [
+                        Chord(root: .F, quality: .maj9), Chord(root: .D, quality: .maj),
+                        Chord(root: .Ab, quality: .maj), Chord(root: .Gb, quality: .maj),
+                        Chord(root: .Eb, quality: .maj),
+                    ],
                     startTime: 11.3
                 ),
                 ChordCell(
                     chord: Chord(root: .Bb, quality: .maj),
-                    chordCandidates: [Chord(root: .Bb, quality: .maj), Chord(root: .D, quality: .maj), Chord(root: .Ab, quality: .maj), Chord(root: .Gb, quality: .maj), Chord(root: .Eb, quality: .maj)],
+                    chordCandidates: [
+                        Chord(root: .Bb, quality: .maj), Chord(root: .D, quality: .maj),
+                        Chord(root: .Ab, quality: .maj), Chord(root: .Gb, quality: .maj),
+                        Chord(root: .Eb, quality: .maj),
+                    ],
                     startTime: 13.0
                 ),
             ]
         )
     }
+}
+
+extension Score {
+    static let recordingFolder: URL = URL.documentsDirectory
+        .appending(component: "Recording", directoryHint: .isDirectory)
 }

--- a/GMG/Core/Models/ScoreFactory/ScoreFactory.swift
+++ b/GMG/Core/Models/ScoreFactory/ScoreFactory.swift
@@ -6,7 +6,6 @@ import Foundation
 import SwiftF0
 
 enum ScoreFactoryError: Error {
-    case documentDirectoryNotFound
     case pitchDetectModelNotFound
     case failedToChordInference
 }
@@ -28,31 +27,17 @@ final class ScoreFactory {
     func createScore(
         audioUrl: URL
     ) throws -> Score {
-        guard
-            let documentDirectory: URL = FileManager.default.urls(
-                for: .documentDirectory,
-                in: .userDomainMask
-            ).first
-        else {
-            throw ScoreFactoryError.documentDirectoryNotFound
-        }
+        let audioFileName: String = audioUrl.lastPathComponent
 
-        let workingFolder: URL = documentDirectory.appendingPathComponent(
-            "Scores",
-            conformingTo: .folder
-        )
-
-        if FileManager.default.fileExists(atPath: workingFolder.path()) == false {
+        if FileManager.default.fileExists(atPath: Score.recordingFolder.path()) == false {
             try FileManager.default.createDirectory(
-                at: workingFolder,
+                at: Score.recordingFolder,
                 withIntermediateDirectories: false
             )
         }
 
-        let workingURL: URL = workingFolder.appendingPathComponent(
-            audioUrl.lastPathComponent,
-            conformingTo: .audio
-        )
+        let workingURL: URL = Score.recordingFolder
+            .appending(component: audioFileName)
 
         try FileManager.default.copyItem(at: audioUrl, to: workingURL)
 
@@ -97,7 +82,7 @@ final class ScoreFactory {
         return Score(
             title: "Untitled",
             key: key,
-            audioUrl: workingURL,
+            audioFileName: audioFileName,
             totalDuration: totalDuration,
             createdAt: Date(),
             updatedAt: Date(),

--- a/GMG/Core/Services/RecordManager.swift
+++ b/GMG/Core/Services/RecordManager.swift
@@ -29,11 +29,8 @@ final class RecordManager {
         try AudioConductor.shared.setAudioMode(.record)
 
         do {
-            let url = FileManager.default.temporaryDirectory
-                .appendingPathComponent(
-                    "recording-\(Date().ISO8601Format()).m4a",
-                    conformingTo: .audio
-                )
+            let url: URL = URL.temporaryDirectory
+                .appending(component: "recording-\(Date().ISO8601Format()).m4a")
             let settings: [String: Any] = [
                 AVFormatIDKey: kAudioFormatMPEG4AAC,
                 AVSampleRateKey: 48_000,


### PR DESCRIPTION
### 설명

앱 업데이트 시 오디오 파일을 찾을 수 없는 문제 수정

### 관련 이슈

Closes #45

### 작업 내용

- [x] Score에 audioFileName 프로퍼티를 추가
- [x] Score의 audioUrl 프로퍼티를 Computed Property로 변경
- [x] `URL.appendingPathComponent` 대신 `URL.appending`으로 변경(iOS 16+)
- [x] `FileManager.default.urls` 대신 `URL.documentsDirectory`으로 변경(iOS 16+)

### 스크린샷 (Optional)



### 참고 내용

기존 Score에 저장된 URL은 절대 경로로 저장되면서 앱 업데이트 시 경로가 변경되는 문제가 있었습니다.

SwiftData 모델이 변경되었기 때문에 이전에 저장한 작업은 모두 사라집니다.

Score 클래스와 SwiftData용 모델을 분리하고 SwiftData용 모델은 버전 관리하는 형식으로 구현해야 할 것 같습니다!

[[SwiftData] Migration과 버전관리](https://inuplace.tistory.com/1362)
[SwiftData로 스키마 모델링하기](https://developer.apple.com/kr/videos/play/wwdc2023/10195)