### PR TITLE
[chore] Xcode에서 pre-commit hook 실행 시 swift-format을 찾을 수 없는 문제 수정

### DIFF
--- a/Scripts/Hooks/pre-commit
+++ b/Scripts/Hooks/pre-commit
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# Ensure Homebrew's bin is in PATH for Apple Silicon Macs
+if [[ "$(uname -m)" == arm64 ]]; then
+    export PATH="/opt/homebrew/bin:$PATH"
+fi
+
 echo "Running swift-format on staged Swift files..."
 
 # Get list of staged .swift files


### PR DESCRIPTION
### 설명

Xcode에서 pre-commit hook 실행 시 swift-format을 찾을 수 없는 문제 수정

### 관련 이슈

Closes #47

### 작업 내용

- [x] pre-commit hook 수정

### 스크린샷 (Optional)



### 참고 내용

`make init` 명령어 실행하면 pre-commit hook 반영됩니다!