### PR TITLE
[bug] `NavigationBar`의 버튼 크기가 작은 문제 수정

### DIFF
--- a/GMG/UI/Components/NavigationBar.swift
+++ b/GMG/UI/Components/NavigationBar.swift
@@ -38,7 +38,7 @@ struct NavigationBar<Leading: View, Center: View, Trailing: View>: View {
 
             center
         }
-        .padding(Spacing.md)
+        .padding(Spacing.xs)
         .buttonStyle(NavigationBarButtonStyle())
     }
 }

--- a/GMG/UI/Styles/NavigationBarButtonStyle.swift
+++ b/GMG/UI/Styles/NavigationBarButtonStyle.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct NavigationBarButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .frame(width: 24, height: 24)
+            .frame(minWidth: 44, minHeight: 44)
             .scaleEffect(configuration.isPressed ? 1.1 : 1.0)
     }
 }


### PR DESCRIPTION
### 설명

`NavigationBar`의 버튼 크기가 작은 문제 수정

### 관련 이슈

Closes #73

### 작업 내용

- [x] `NavigationBarButtonStyle`에서 Label 프레임을 최소 44 이상이 되도록 수정

### 스크린샷 (Optional)

<p align="center">
  <img width="256" alt="NavigationBar" src="https://github.com/user-attachments/assets/90a2ff3a-7028-4a41-80e5-3379fc7b3e2d" />
</p>

### 참고 내용

