### PR TITLE
[refactor] ScoreFactory에 Swift Concurrency 적용

### DIFF
--- a/GMG/Core/Models/ScoreFactory/ChordInferencer.swift
+++ b/GMG/Core/Models/ScoreFactory/ChordInferencer.swift
@@ -58,7 +58,7 @@ final class ChordInferencer {
         self.vocab = try JSONDecoder().decode(Vocab.self, from: vocabData)
     }
 
-    func inference(notes: [Note]) throws -> ChordInferencerResult {
+    func inference(notes: [Note]) async throws -> ChordInferencerResult {
         guard !notes.isEmpty else {
             return ChordInferencerResult(key: Key(root: .C), chordCells: [])
         }
@@ -96,7 +96,7 @@ final class ChordInferencer {
                 }
                 .flatMap { $0.tokens }
 
-            let inferenceResults: [[InferenceResult]] = try inference(
+            let inferenceResults: [[InferenceResult]] = try await inference(
                 tokens: slicedTokens,
                 previousResults: previousResults
             )
@@ -174,7 +174,7 @@ extension ChordInferencer {
     private func inference(
         tokens: [String],
         previousResults: [[InferenceResult]]? = nil
-    ) throws -> [[InferenceResult]] {
+    ) async throws -> [[InferenceResult]] {
         var tokenIds: [Int] = []
 
         tokenIds.reserveCapacity(maxMelodyLength)
@@ -205,7 +205,7 @@ extension ChordInferencer {
 
         let melodyTokens = MLMultiArray(melodyArray)
 
-        let chordInferenceResults = try generateOutputSequence(
+        let chordInferenceResults = try await generateOutputSequence(
             melodyTokens: melodyTokens,
             previousResults: previousResults,
             topK: 5,
@@ -220,7 +220,7 @@ extension ChordInferencer {
         previousResults: [[InferenceResult]]? = nil,
         topK: Int? = 5,
         temperature: Float = 0.9
-    ) throws -> [[InferenceResult]] {
+    ) async throws -> [[InferenceResult]] {
         var results: [[InferenceResult]] = previousResults ?? []
 
         var chordArray: MLShapedArray<Int32> = MLShapedArray(
@@ -242,7 +242,7 @@ extension ChordInferencer {
                     melody_tokens: melodyTokens,
                     chord_input: chordInput
                 )
-            let output: TransformerChordInferenceOutput = try model.prediction(
+            let output: TransformerChordInferenceOutput = try await model.prediction(
                 input: input
             )
 

--- a/GMG/Core/Models/ScoreFactory/ScoreFactory.swift
+++ b/GMG/Core/Models/ScoreFactory/ScoreFactory.swift
@@ -44,7 +44,7 @@ final class ScoreFactory {
 
     func createScore(
         audioURL: URL
-    ) throws -> Score {
+    ) async throws -> Score {
         let audioFileName: String = audioURL.lastPathComponent
 
         if FileManager.default.fileExists(atPath: Score.recordingFolder.path()) == false {
@@ -61,13 +61,15 @@ final class ScoreFactory {
 
         scoreFactoryStatePublisher.send(.hummingAnalysis)
 
-        let notes: [Note] = try self.convertAudioToNotes(audioURL: copiedAudioURL)
+        let notes: [Note] = try await Task.detached {
+            return try await self.convertAudioToNotes(audioURL: copiedAudioURL)
+        }.value
 
         scoreFactoryStatePublisher.send(.chordGeneration)
 
         let inferencer = try ChordInferencer()
         let chordInferencerResult: ChordInferencerResult =
-            try inferencer.inference(notes: notes)
+            try await inferencer.inference(notes: notes)
 
         let key: Key = chordInferencerResult.key
         let chordCells: [ChordCell] = chordInferencerResult.chordCells
@@ -112,7 +114,7 @@ final class ScoreFactory {
         )
     }
 
-    private func convertAudioToNotes(audioURL: URL) throws -> [Note] {
+    private nonisolated func convertAudioToNotes(audioURL: URL) async throws -> [Note] {
         guard
             let modelURL: URL = Bundle.main.url(
                 forResource: "SwiftF0",
@@ -153,7 +155,7 @@ final class ScoreFactory {
 }
 
 extension SwiftF0.Note {
-    fileprivate var note: Note {
+    fileprivate nonisolated var note: Note {
         let noteNames: [NoteName] = [
             .C,
             .Cs,

--- a/GMG/Scenes/Recording/RecordingIntent.swift
+++ b/GMG/Scenes/Recording/RecordingIntent.swift
@@ -224,20 +224,7 @@ final class RecordingIntent: RecordingIntentProtocol {
             else { return }
 
             do {
-                // TODO: Swift Concurrency 방법 찾아보기!
-                // DispatchQueue.global()을 사용하지 않으면 MainThread에서 실행되어 로딩 화면이 안나옴
-                let score: Score = try await withCheckedThrowingContinuation {
-                    continuation in
-                    DispatchQueue.global().async {
-                        do {
-                            let score: Score = try self.scoreFactory
-                                .createScore(audioURL: url)
-                            continuation.resume(returning: score)
-                        } catch {
-                            continuation.resume(throwing: error)
-                        }
-                    }
-                }
+                let score: Score = try await self.scoreFactory.createScore(audioURL: url)
 
                 try self.scoreRepository.insert(score)
 


### PR DESCRIPTION
### 설명

기존 `DispatchQueue.global().async`로 구현한 Score 생성 코드에 Swift Concurrency를 적용합니다.

### 관련 이슈

Closes #82

### 작업 내용

- [x] `ChordInferencer`의 추론 코드에 `await`을 적용하여 비동기로 실행될 수 있도록 수정
- [x] `SwiftF0`를 `Task.detached`를 사용하여 MainActor에서 실행되지 않도록 수정

### 스크린샷 (Optional)

#### ASIS

주황색 부분이 UI 반응성이 떨어지는 부분입니다.

<p align="center">
  <img width="512" alt="ASIS" src="https://github.com/user-attachments/assets/ddf96d70-28d4-47e8-97d0-1b8438bc9cc0" />
</p>

#### TOBE

메인 스레드에서 처리되는 태스크를 다른 스레드에서 처리되는 모습입니다.

<p align="center">
  <img width="512" alt="TOBE" src="https://github.com/user-attachments/assets/b59aa172-e375-4068-84e6-4cf41853c720" />
</p>

### 참고 내용

`ScoreFactory`를 통해 `Score`를 생성할 때 `DispatchQueue.global().async`를 사용하지 않고 생성하면, 로딩 뷰가 제대로 표시되지 않는 문제가 있었습니다.

문제 원인은 MainActor에서 생성된 Task가 다른 컨텍스트으로 전환되지 않아 Main Thread에서 처리하는 것이었습니다.

`ScoreFactory`의 `scoreFactoryStatePublisher`는 MainActor에서 실행되기 때문에 이에 접근하는 `createFactory` 메서드도 MainActor에서 실행됩니다. 이를 해결하기 위해 메서드 내부에서 컨텍스트 전환을 일어나도록 위의 작업 내용을 반영하였습니다.