### PR TITLE
[bug] `ChordProgressView`에서 오디오 소스 변경 시 재생이 되지 않는 문제 수정

### DIFF
--- a/GMG/Core/Models/ScorePlayer/ScorePlayer.swift
+++ b/GMG/Core/Models/ScorePlayer/ScorePlayer.swift
@@ -30,6 +30,8 @@ final class ScorePlayer {
     let playheadPublisher: CurrentValueSubject<Playhead, Never>
     private var playheadPublisherTimer: AnyCancellable?
 
+    private var routeChangeObserver: NSObjectProtocol?
+
     init(score: Score) {
         self.score = score
 
@@ -56,10 +58,14 @@ final class ScorePlayer {
             )
         )
         self.playheadPublisherTimer = nil
+
+        self.routeChangeObserver = nil
     }
 
     /// onAppear 시 실행될 메서드
     func prepareToPlay() throws {
+        try activateAudioSession()
+
         engine.attach(sampler)
         engine.connect(sampler, to: engine.mainMixerNode, format: nil)
 
@@ -100,12 +106,29 @@ final class ScorePlayer {
                 )
             )
         }
+
+        routeChangeObserver = NotificationCenter.default.addObserver(
+            forName: AVAudioSession.routeChangeNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] notification in
+            try? self?.activateAudioSession()
+
+            try? self?.engine.start()
+        }
     }
 
     /// onDisappear 시 실행될 메서드
     func cleanupAfterPlay() {
+        try? deactivateAudioSession()
+
         playheadPublisherTimer?.cancel()
         playheadPublisherTimer = nil
+
+        if let observer = routeChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            routeChangeObserver = nil
+        }
 
         engine.stop()
     }
@@ -294,6 +317,23 @@ final class ScorePlayer {
             at: nil,
             completionHandler: nil
         )
+    }
+
+    private func activateAudioSession() throws {
+        let audioSession: AVAudioSession = AVAudioSession.sharedInstance()
+
+        try audioSession.setCategory(
+            .playback,
+            mode: .default,
+            options: []
+        )
+        try audioSession.setActive(true)
+    }
+
+    private func deactivateAudioSession() throws {
+        let audioSession: AVAudioSession = AVAudioSession.sharedInstance()
+
+        try audioSession.setActive(false)
     }
 
     private func currentPlaybackTime() -> TimeInterval {

--- a/GMG/Core/Services/PlaybackManager.swift
+++ b/GMG/Core/Services/PlaybackManager.swift
@@ -26,6 +26,8 @@ final class PlaybackManager: NSObject, AVAudioPlayerDelegate {
     }
 
     func play(_ url: URL) throws {
+        try activateAudioSession()
+
         do {
             let audioPlayer: AVAudioPlayer = try AVAudioPlayer(contentsOf: url)
 
@@ -57,6 +59,8 @@ final class PlaybackManager: NSObject, AVAudioPlayerDelegate {
     }
 
     func stop() {
+        try? deactivateAudioSession()
+
         guard let audioPlayer else { return }
 
         audioPlayer.stop()
@@ -66,6 +70,23 @@ final class PlaybackManager: NSObject, AVAudioPlayerDelegate {
 
         self.isPlayingPublisher.send(audioPlayer.isPlaying)
         self.playedDurationPublisher.send(audioPlayer.duration)
+    }
+
+    private func activateAudioSession() throws {
+        let audioSession: AVAudioSession = AVAudioSession.sharedInstance()
+
+        try audioSession.setCategory(
+            .playback,
+            mode: .default,
+            options: []
+        )
+        try audioSession.setActive(true)
+    }
+
+    private func deactivateAudioSession() throws {
+        let audioSession: AVAudioSession = AVAudioSession.sharedInstance()
+
+        try audioSession.setActive(false)
     }
 
     private func updateMeter() {

--- a/GMG/Core/Services/RecordManager.swift
+++ b/GMG/Core/Services/RecordManager.swift
@@ -98,7 +98,6 @@ final class RecordManager {
         let audioSession: AVAudioSession = AVAudioSession.sharedInstance()
 
         try audioSession.setActive(false)
-
     }
 
     private func updateRecordedDuration() {


### PR DESCRIPTION
### 설명

`ChordProgressView`에서 오디오 소스 변경 시 재생이 되지 않는 문제 수정

### 관련 이슈

Closes #50

### 작업 내용

- [x] NotificationCenter로 AudioSession의 라우트가 변경될 경우 엔진을 다시 시작하도록 수정
- [x] `PlaybackManager`와 `ScorePlayer`가 AudioSession을 활성화하도록 수정

### 스크린샷 (Optional)



### 참고 내용

