### PR TITLE
[chore] 녹음 및 사진 라이브러리 권한 설명 수정

### DIFF
--- a/GMG.xcodeproj/project.pbxproj
+++ b/GMG.xcodeproj/project.pbxproj
@@ -371,8 +371,8 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = GMG/Info.plist;
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "This app requires access to the microphone to record audio.";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "This app requires access to the Photo Library to save photo.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Microphone access is required to record audio for chord detection.";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Access to your photo library is required to save the chord sheet.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -424,8 +424,8 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = GMG/Info.plist;
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "This app requires access to the microphone to record audio.";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "This app requires access to the Photo Library to save photo.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Microphone access is required to record audio for chord detection.";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Access to your photo library is required to save the chord sheet.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/GMG/Resources/Localization/Localizable.xcstrings
+++ b/GMG/Resources/Localization/Localizable.xcstrings
@@ -348,19 +348,36 @@
         }
       }
     },
-    "RequestMicrophoneAccessPermission" : {
+    "RequestMicrophoneAccessPermissionAlertDescription" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Microphone access is required for recording."
+            "value" : "To record audio for chord detection, please allow the app to access your microphone."
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "녹음을 위해서는 마이크 접근 권한이 필요합니다."
+            "value" : "코드 추론을 위한 사운드를 녹음하기 위해 마이크에 액세스 할 수 있는 권한을 허용해주세요."
+          }
+        }
+      }
+    },
+    "RequestMicrophoneAccessPermissionAlertTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Microphone Access Required"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "마이크 접근 권한이 필요합니다."
           }
         }
       }

--- a/GMG/Resources/Localization/en.lproj/InfoPlist.strings
+++ b/GMG/Resources/Localization/en.lproj/InfoPlist.strings
@@ -1,3 +1,4 @@
 //  Copyright © 2025 ADA 4th GMG. All rights reserved.
 
-NSMicrophoneUsageDescription = "Microphone access is required for recording.";
+NSMicrophoneUsageDescription = "Microphone access is required to record audio for chord detection.";
+NSPhotoLibraryAddUsageDescription = "Access to your photo library is required to save the chord sheet.";

--- a/GMG/Resources/Localization/ko.lproj/InfoPlist.strings
+++ b/GMG/Resources/Localization/ko.lproj/InfoPlist.strings
@@ -1,3 +1,4 @@
 //  Copyright © 2025 ADA 4th GMG. All rights reserved.
 
-NSMicrophoneUsageDescription = "녹음을 위해서는 마이크 접근 권한이 필요합니다.";
+NSMicrophoneUsageDescription = "코드 추론을 위한 사운드를 녹음하기 위해 마이크에 액세스 할 수 있는 권한이 필요합니다.";
+NSPhotoLibraryAddUsageDescription = "코드 시트를 저장하려면 사진 라이브러리 접근 권한이 필요합니다.";

--- a/GMG/Scenes/Recording/RecordingView.swift
+++ b/GMG/Scenes/Recording/RecordingView.swift
@@ -81,7 +81,7 @@ struct RecordingView: View {
             await intent.onAppear()
         }
         .alert(
-            .requestMicrophoneAccessPermission,
+            .requestMicrophoneAccessPermissionAlertTitle,
             isPresented: .constant(model.isRecordPermissionAlertPresented)
         ) {
             Button(.openSettings) {
@@ -91,6 +91,8 @@ struct RecordingView: View {
             Button(.cancel, role: .cancel) {
                 intent.onTapRecordPermissionAlertCancelButton()
             }
+        } message: {
+            Text(.requestMicrophoneAccessPermissionAlertDescription)
         }
         .alert(
             .resetConfirmationAlert, isPresented: .constant(model.isResetConfirmationAlertPresented)


### PR DESCRIPTION
### 설명

[chore] 녹음 및 사진 라이브러리 권한 설명 수정

### 관련 이슈

Closes #97

### 작업 내용

- [x] 녹음 권한 설명 수정
- [x] 사진 라이브러리 권한 설명 수정

### 스크린샷 (Optional)

<p align="center">
  <img width="256" alt="Permission Request" src="https://github.com/user-attachments/assets/d26ed275-a565-4eb3-9fde-3152fff34a96" />
  <img width="256" alt="Alert" src="https://github.com/user-attachments/assets/ce108791-3c0e-4c86-9931-9e040747d43e" />
</p>

### 참고 내용

Photo Library 권한이 `NSPhotoLibraryUsageDescription`로 되어 있는데 사진 불러오는 기능은 없어서 `NSPhotoLibraryAddUsageDescription`로 수정했습니다.

[Requesting authorization to capture and save media](https://developer.apple.com/documentation/avfoundation/requesting-authorization-to-capture-and-save-media)

> If your app only needs to save video to the photo library, the [UISaveVideoAtPathToSavedPhotosAlbum(_:_:_:_:)](https://developer.apple.com/documentation/UIKit/UISaveVideoAtPathToSavedPhotosAlbum(_:_:_:_:)) function is a simpler alternative to [PHPhotoLibrary](https://developer.apple.com/documentation/Photos/PHPhotoLibrary). This function only requires write access to the library. Use the [NSPhotoLibraryAddUsageDescription](https://developer.apple.com/documentation/BundleResources/Information-Property-List/NSPhotoLibraryAddUsageDescription) key in your Info.plist file to provide the user a message to request permission to save to the photo library.
앱이 비디오만 사진 라이브러리에 저장해야 하는 경우, UISaveVideoAtPathToSavedPhotosAlbum(_:_:_:_:) 함수는 PHPhotoLibrary 에 비해 더 간단한 대안입니다. 이 함수는 라이브러리에 대한 쓰기 권한만 필요합니다. Info.plist 파일에 NSPhotoLibraryAddUsageDescription 키를 사용하여 사진 라이브러리 저장 권한을 요청하는 메시지를 사용자에게 제공하세요.