### PR TITLE
[bug] SwiftData Schema의 구조체를 @Model로 변경

### DIFF
--- a/GMG/Core/Data/Schema/ScoreSchemaV1.swift
+++ b/GMG/Core/Data/Schema/ScoreSchemaV1.swift
@@ -7,8 +7,9 @@ enum ScoreSchemaV1: VersionedSchema {
     static var versionIdentifier: Schema.Version {
         Schema.Version(1, 0, 0)
     }
+
     static var models: [any PersistentModel.Type] {
-        [Score.self]
+        [Score.self, ChordCell.self, Chord.self, Key.self, Note.self]
     }
 
     @Model
@@ -20,8 +21,8 @@ enum ScoreSchemaV1: VersionedSchema {
         var totalDuration: TimeInterval = TimeInterval.zero
         var createdAt: Date = Date.now
         var updatedAt: Date = Date.now
-        var notes: [Note] = []
-        var chordCells: [ChordCell] = []
+        @Relationship(deleteRule: .cascade) var notes: [Note] = []
+        @Relationship(deleteRule: .cascade) var chordCells: [ChordCell] = []
         var audioLevels: [Float] = []
         var isDeleted: Bool = false
 
@@ -52,18 +53,43 @@ enum ScoreSchemaV1: VersionedSchema {
         }
     }
 
-    struct ChordCell: Codable {
-        var chord: Chord?
-        var chordCandidates: [Chord]
-        var startTime: TimeInterval
+    @Model
+    class ChordCell {
+        @Relationship(deleteRule: .cascade) var chord: Chord? = nil
+        @Relationship(deleteRule: .cascade) var chordCandidates: [Chord] = []
+        var startTime: TimeInterval = TimeInterval.zero
+
+        init(
+            chord: Chord?,
+            chordCandidates: [Chord],
+            startTime: TimeInterval
+        ) {
+            self.chord = chord
+            self.chordCandidates = chordCandidates
+            self.startTime = startTime
+        }
     }
 
-    struct Chord: Codable {
-        let root: NoteName
-        let quality: ChordQuality
+    @Model
+    class Chord {
+        var rootRaw: NoteName.RawValue = NoteName.C.rawValue
+        var root: NoteName {
+            get { .init(rawValue: rootRaw) ?? .C }
+            set { rootRaw = newValue.rawValue }
+        }
+        var qualityRaw: ChordQuality.RawValue = ChordQuality.maj.rawValue
+        var quality: ChordQuality {
+            get { .init(rawValue: qualityRaw) ?? .maj }
+            set { qualityRaw = newValue.rawValue }
+        }
+
+        init(root: NoteName, quality: ChordQuality) {
+            self.root = root
+            self.quality = quality
+        }
     }
 
-    enum ChordQuality: Codable {
+    enum ChordQuality: String {
         case maj
         case maj7
         case maj9
@@ -76,18 +102,39 @@ enum ScoreSchemaV1: VersionedSchema {
         case halfDim7
     }
 
-    struct Key: Codable {
-        let root: NoteName
+    @Model
+    class Key {
+        var rootRaw: NoteName.RawValue = NoteName.C.rawValue
+        var root: NoteName {
+            get { .init(rawValue: rootRaw) ?? .C }
+            set { rootRaw = newValue.rawValue }
+        }
+
+        init(root: NoteName) {
+            self.root = root
+        }
     }
 
-    struct Note: Codable {
-        let name: NoteName
-        let octave: Int
-        let startTime: TimeInterval
-        let duration: TimeInterval
+    @Model
+    class Note {
+        var nameRaw: NoteName.RawValue = NoteName.C.rawValue
+        var name: NoteName {
+            get { .init(rawValue: nameRaw) ?? .C }
+            set { nameRaw = newValue.rawValue }
+        }
+        var octave: Int = Int.zero
+        var startTime: TimeInterval = TimeInterval.zero
+        var duration: TimeInterval = TimeInterval.zero
+
+        init(name: NoteName, octave: Int, startTime: TimeInterval, duration: TimeInterval) {
+            self.name = name
+            self.octave = octave
+            self.startTime = startTime
+            self.duration = duration
+        }
     }
 
-    enum NoteName: Codable {
+    enum NoteName: String {
         case C
         case Cs
         case Db

--- a/GMG/Navigation/Router.swift
+++ b/GMG/Navigation/Router.swift
@@ -53,7 +53,7 @@ final class Router {
 
                 RecordingView(model: model, intent: intent, router: self)
             } else {
-                Text("Error")
+                ErrorView(description: "Failed to create database")
             }
         case .chordProgress(let score):
             if let scoreRepository: ScoreRepository = diContainer.makeScoreRepository() {
@@ -63,7 +63,7 @@ final class Router {
 
                 ChordProgressView(model: model, intent: intent, router: self)
             } else {
-                Text("Error")
+                ErrorView(description: "Failed to create database")
             }
         case .export(let score):
             let model: ExportModel = ExportModel(score: score)


### PR DESCRIPTION
### 설명

SwiftData에서 struct로 선언된 프로퍼티는 내부적으로 Data로 변환되어 저장되는데 이 데이터는 마이그레이션이 사실상 불가능하다고 해서 `@Model` 클래스로 변경하였습니다.

### 관련 이슈

Closes #103

### 작업 내용

- [x] SwiftData Schema의 구조체를 @Model로 변경 

### 스크린샷 (Optional)



### 참고 내용

스키마 구조가 바뀌어서 삭제 후 재설치 부탁드립니다!

ChordCell에 duration 추가해서 마이그레이션 테스트 결과 잘되는 것 확인했습니다. 필요하시면 아래 패치 파일로 테스트해봐도 좋을 것 같습니다!

```shell
git apply Swift\ Migration\ Test
```

[SwiftData Migration Test.zip](https://github.com/user-attachments/files/23617771/SwiftData.Migration.Test.zip)
