### PR TITLE
[chore] Environment로 주입한 Locale에 따라 프리뷰에서 나타나지 않는 문제 수정

### DIFF
--- a/GMG/Scenes/ChordProgress/ChordProgressView.swift
+++ b/GMG/Scenes/ChordProgress/ChordProgressView.swift
@@ -166,7 +166,7 @@ extension ChordProgressView {
         var body: some View {
             ZStack(alignment: .center) {
                 TextField(
-                    String(localized: .enterTitle),
+                    LocalizedStringKey(LocalizedStringResource.enterTitle.key),
                     text: isTitleFieldFocused ? $titleDraft : .constant(title)
                 )
                 .multilineTextAlignment(.center)
@@ -327,7 +327,7 @@ extension ChordProgressView {
         var body: some View {
             HStack(spacing: .zero) {
                 ToggleButton(
-                    title: String(localized: .sheet),
+                    title: .sheet,
                     isSelected: !isEditMode,
                     namespace: namespace
                 ) {
@@ -335,7 +335,7 @@ extension ChordProgressView {
                 }
 
                 ToggleButton(
-                    title: String(localized: .edit),
+                    title: .edit,
                     isSelected: isEditMode,
                     namespace: namespace
                 ) {
@@ -347,16 +347,40 @@ extension ChordProgressView {
         }
 
         struct ToggleButton: View {
-            let title: String
+            let title: Text
             let isSelected: Bool
             let namespace: Namespace.ID
             let action: () -> Void
+
+            init<S: StringProtocol>(
+                title: S,
+                isSelected: Bool,
+                namespace: Namespace.ID,
+                action: @escaping () -> Void
+            ) {
+                self.title = Text(title)
+                self.isSelected = isSelected
+                self.namespace = namespace
+                self.action = action
+            }
+
+            init(
+                title: LocalizedStringResource,
+                isSelected: Bool,
+                namespace: Namespace.ID,
+                action: @escaping () -> Void
+            ) {
+                self.title = Text(title)
+                self.isSelected = isSelected
+                self.namespace = namespace
+                self.action = action
+            }
 
             var body: some View {
                 Button {
                     action()
                 } label: {
-                    Text(title)
+                    title
                         .font(
                             .english(
                                 isSelected

--- a/GMG/Scenes/Home/HomeView.swift
+++ b/GMG/Scenes/Home/HomeView.swift
@@ -118,7 +118,7 @@ extension HomeView {
             HStack {
                 VStack(alignment: .leading, spacing: .zero) {
                     TextField(
-                        String(localized: .enterTitle),
+                        LocalizedStringKey(LocalizedStringResource.enterTitle.key),
                         text: isEditable ? $tempTitle : .constant(score.title)
                     )
                     .font(isSmall ? Typography.WantedSansStd.R4 : Typography.WantedSansStd.R5)

--- a/GMG/Scenes/Recording/LoadingView.swift
+++ b/GMG/Scenes/Recording/LoadingView.swift
@@ -29,7 +29,7 @@ struct LoadingView: View {
 
                 VStack(alignment: .leading, spacing: Spacing.xs) {
                     ForEach(ScoreFactoryState.allCases, id: \.self) { state in
-                        LoadingStateRow(text: String(localized: state.localizedStringResource))
+                        LoadingStateRow(state.localizedStringResource)
                             .disabled(scoreFactoryState.rawValue < state.rawValue)
                     }
                 }
@@ -38,9 +38,17 @@ struct LoadingView: View {
     }
 
     struct LoadingStateRow: View {
-        let text: String
+        @Environment(\.isEnabled) private var isEnabled: Bool
 
-        @Environment(\.isEnabled) private var isEnabled
+        let text: Text
+
+        init<S: StringProtocol>(_ string: S) {
+            self.text = Text(string)
+        }
+
+        init(_ resource: LocalizedStringResource) {
+            self.text = Text(resource)
+        }
 
         private var color: Color {
             isEnabled ? Color.black1 : Color.black7
@@ -51,7 +59,7 @@ struct LoadingView: View {
                 Image(.checkmark)
                     .frame(width: 20, height: 20)
                     .background(color, in: Circle())
-                Text(text)
+                text
                     .font(
                         .english(Typography.WantedSansStd.R6),
                         .korean(Typography.Pretendard.M6)
@@ -68,4 +76,5 @@ struct LoadingView: View {
     PhaseAnimator(ScoreFactoryState.allCases) { state in
         LoadingView(scoreFactoryState: state)
     }
+    .environment(\.locale, .init(languageCode: .english))
 }

--- a/GMG/Scenes/Recording/RecordingView.swift
+++ b/GMG/Scenes/Recording/RecordingView.swift
@@ -252,15 +252,15 @@ struct RecordingView: View {
         let stopPlayAction: () -> Void
         let nextAction: () -> Void
 
-        private var primaryButtonTitle: String {
+        private var primaryButtonTitle: LocalizedStringResource {
             if isRecording {
-                return String(localized: .stop)
+                return .stop
             } else if isPlaying {
-                return String(localized: .stop)
+                return .stop
             } else if recordingURL != nil {
-                return String(localized: .replay)
+                return .replay
             }
-            return String(localized: .record)
+            return .record
         }
 
         private var primaryButtonImage: ImageResource {


### PR DESCRIPTION
### 설명

Environment로 주입한 Locale에 따라 프리뷰에서 나타나지 않는 문제 수정

### 관련 이슈

Closes #108

### 작업 내용

- [x] `String(localized:)`를 LocalizedStringResource나 LocalizedStringKey를 사용하도록 수정

### 스크린샷 (Optional)

<p align="center">
  <img width="256" alt="LocalizedStringResource" src="https://github.com/user-attachments/assets/ce8fdf0d-0ff2-450b-bdb7-43d7918141a2" />
</p>

### 참고 내용

