### PR TITLE
[bug] ChordProgressView의 UI가 깨지는 문제 수정

### DIFF
--- a/GMG/Core/Data/Repository/ScoreRepository.swift
+++ b/GMG/Core/Data/Repository/ScoreRepository.swift
@@ -23,7 +23,12 @@ final class SwiftDataScoreRepository: ScoreRepository {
     func fetch() throws -> [Score] {
         /// Soft Delete 되지 않은 Score만 가져오기
         let predicate: Predicate<ScoreSchema.Score> = #Predicate { $0.isDeleted == false }
-        let fetchDescriptor: FetchDescriptor<ScoreSchema.Score> = .init(predicate: predicate)
+        let fetchDescriptor: FetchDescriptor<ScoreSchema.Score> = .init(
+            predicate: predicate,
+            sortBy: [
+                .init(\.createdAt, order: .forward)
+            ]
+        )
         let scorePersitences: [ScoreSchema.Score] = try context.fetch(fetchDescriptor)
 
         let scores: [Score] = scorePersitences.map { $0.toDomain() }
@@ -118,8 +123,10 @@ extension ScoreSchema.Score {
             totalDuration: self.totalDuration,
             createdAt: self.createdAt,
             updatedAt: self.updatedAt,
-            notes: self.notes.map { $0.toDomain() },
-            chordCells: self.chordCells.map { $0.toDomain() },
+            notes: self.notes.map { $0.toDomain() }.sorted(by: { $0.startTime < $1.startTime }),
+            chordCells: self.chordCells.map { $0.toDomain() }.sorted(by: {
+                $0.startTime < $1.startTime
+            }),
             audioLevels: self.audioLevels,
             isDeleted: self.isDeleted
         )
@@ -206,16 +213,22 @@ extension ScoreSchema.Key {
 extension Note {
     fileprivate func toPersistence() -> ScoreSchema.Note {
         return .init(
-            name: self.name.toPersistence(), octave: self.octave, startTime: self.startTime,
-            duration: self.duration)
+            name: self.name.toPersistence(),
+            octave: self.octave,
+            startTime: self.startTime,
+            duration: self.duration
+        )
     }
 }
 
 extension ScoreSchema.Note {
     fileprivate func toDomain() -> Note {
         return .init(
-            name: self.name.toDomain(), octave: self.octave, startTime: self.startTime,
-            duration: self.duration)
+            name: self.name.toDomain(),
+            octave: self.octave,
+            startTime: self.startTime,
+            duration: self.duration
+        )
     }
 }
 
@@ -270,7 +283,8 @@ extension ChordCell {
         return .init(
             chord: self.chord?.toPersistence(),
             chordCandidates: self.chordCandidates.map { $0.toPersistence() },
-            startTime: self.startTime)
+            startTime: self.startTime
+        )
     }
 }
 
@@ -278,6 +292,8 @@ extension ScoreSchema.ChordCell {
     fileprivate func toDomain() -> ChordCell {
         return .init(
             chord: self.chord?.toDomain(),
-            chordCandidates: self.chordCandidates.map { $0.toDomain() }, startTime: self.startTime)
+            chordCandidates: self.chordCandidates.map { $0.toDomain() },
+            startTime: self.startTime
+        )
     }
 }


### PR DESCRIPTION
### 설명

ChordProgressView의 UI가 깨지는 문제 수정

### 관련 이슈

Closes #117

### 작업 내용

- [x] SwiftData에서 ChordCell을 가져올 때 정렬되지 않은 상태로 가져오는 문제 수정

### 스크린샷 (Optional)

다음과 같은 형식으로 나타나는 문제를 해결하였습니다.

<p align="center">
  <img width="256" alt="1" src="https://github.com/user-attachments/assets/e003049b-56be-4fc6-9ffe-dea54b8f6857" />
  <img width="256" alt="2" src="https://github.com/user-attachments/assets/47081050-8a9b-4870-9a74-52b3fcd36082" />
  <img width="256" alt="3" src="https://github.com/user-attachments/assets/c8745783-b8b5-4470-8cea-33711062ad52" />
</p>

### 참고 내용

`ChordCell`을 `@Model`로 바꾸면서 `Score`를 가져올 때 `ChordCell`의 순서가 보장되지 않는 문제가 있었습니다.
Repository에서 가져올 때 정렬하여 Score를 생성하도록 개선하였습니다.