### PR TITLE
[bug] 오디오 루트 변경 시 사운드 폰트가 초기화되는 문제 수정

### DIFF
--- a/GMG/Core/Models/ScorePlayer/ScorePlayer.swift
+++ b/GMG/Core/Models/ScorePlayer/ScorePlayer.swift
@@ -54,13 +54,14 @@ final class DefaultScorePlayer: ScoreAudioEngineBase, ScorePlayer {
 
     /// onAppear 시 실행될 메서드
     func prepareToPlay() throws {
-        try activateAudioSession()
-
         attachNodes()
-        try loadAudioFile(score.audioURL)
+
+        try activateAudioSession()
         try engine.start()
 
-        scheduleAudioFile(from: .zero)
+        try loadAudioFile(score.audioURL)
+
+        // 코드 재생 준비
         try loadSoundBank()
         prepareChordCells()
 
@@ -94,6 +95,11 @@ final class DefaultScorePlayer: ScoreAudioEngineBase, ScorePlayer {
                 do {
                     try self.activateAudioSession()
                     try self.engine.start()
+
+                    Task {
+                        try? await Task.sleep(for: .seconds(0.1))
+                        try? self.loadSoundBank()
+                    }
                 } catch {
                     Logger.error(String(describing: error))
                 }
@@ -110,7 +116,6 @@ final class DefaultScorePlayer: ScoreAudioEngineBase, ScorePlayer {
     }
 
     func play() {
-
         if engine.isRunning == false {
             try? engine.start()
         }

--- a/GMG/Core/Models/ScorePlayer/ScorePlayer.swift
+++ b/GMG/Core/Models/ScorePlayer/ScorePlayer.swift
@@ -93,12 +93,19 @@ final class DefaultScorePlayer: ScoreAudioEngineBase, ScorePlayer {
                 guard let self else { return }
 
                 do {
+                    let wasPlaying = self.player.isPlaying
+                    self.pause()
+
                     try self.activateAudioSession()
                     try self.engine.start()
 
                     Task {
                         try? await Task.sleep(for: .seconds(0.1))
                         try? self.loadSoundBank()
+
+                        if wasPlaying {
+                            self.play()
+                        }
                     }
                 } catch {
                     Logger.error(String(describing: error))


### PR DESCRIPTION
### 설명

오디오 루트 변경 시 사운드 폰트가 초기화되는 문제 수정

### 관련 이슈

Closes #127

### 작업 내용

- [x] 오디오 루트 변경 시 사운드 폰트 다시 불러오도록 수정

### 스크린샷 (Optional)



### 참고 내용

엔진 시작 후 바로 사운드 폰트를 불러오면 적용이 안되는 문제가 있어서 0.1초 딜레이를 넣었습니다.