### PR TITLE
[bug] RecordingView에서 버튼 크기가 변경될 때 레이블 위치가 같이 움직이는 문제 수정

### DIFF
--- a/GMG/UI/Components/ControllerButton.swift
+++ b/GMG/UI/Components/ControllerButton.swift
@@ -25,6 +25,7 @@ struct ControllerButton<Label: View>: View {
                 .foregroundStyle(
                     isDark ? Color.white1 : Color.black1
                 )
+                .geometryGroup()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(
                     isDark ? Color.black : Color.white,


### PR DESCRIPTION
### 설명

RecordingView에서 버튼 크기가 변경될 때 레이블 위치가 같이 움직이는 문제 수정

### 관련 이슈

Closes #130

### 작업 내용

- [x] ControllerButton의 label에 `.geometryGroup()` 적용

### 스크린샷 (Optional)

<p align="center">
  <img width="256" alt="Before" src="https://github.com/user-attachments/assets/30a2e58c-7b75-4e8b-9605-4c7b4b91d689">
  <img width="256" alt="After" src="https://github.com/user-attachments/assets/3b91d9b2-0137-4bb0-a787-6be536365b84">
</p>

### 참고 내용

[geometryGroup() | Apple Developer Documentation](https://developer.apple.com/documentation/swiftui/view/geometrygroup())

`.geometryGroup()`은 부모 뷰의 geometry 계산 및 애니메이션 적용이 끝난 뒤에 자식 뷰에 geometry를 적용하는 기능이라고 합니다.