### PR TITLE
[bug] RecordingView Waveform이 화면 크기에 대응하도록 개선

### DIFF
--- a/GMG/Scenes/Recording/RecordingView.swift
+++ b/GMG/Scenes/Recording/RecordingView.swift
@@ -212,30 +212,56 @@ struct RecordingView: View {
     struct WaveForm: View {
         let audioLevels: [Float]
 
-        private var paddedAudioLevels: [Float] {
-            Array(
-                repeating: .zero,
-                count: max(0, 34 - audioLevels.count)
-            ) + Array(audioLevels.suffix(34))
-        }
+        private let spacing: CGFloat = 7
+        private let capsuleWidth: CGFloat = 3
+        private let capsuleMinHeight: CGFloat = 6
+        private let capsuleMaxHeight: CGFloat = 80
 
         var body: some View {
-            HStack(spacing: Spacing.xs) {
-                ForEach(
-                    Array(paddedAudioLevels.enumerated()),
-                    id: \.offset
-                ) { _, audioLevel in
-                    let height: CGFloat = CGFloat(80 * audioLevel + 10)
+            GeometryReader { geometry in
+                let width: CGFloat = geometry.size.width
 
-                    Capsule()
-                        .foregroundStyle(Color.gray)
-                        .frame(width: 3, height: height)
+                let capsuleCount: Int = Int(width / (capsuleWidth + spacing))
+                let levelsToDraw: [Float] = processLevels(count: capsuleCount)
+
+                Canvas { context, size in
+                    let startX: CGFloat =
+                        (width - CGFloat(capsuleCount) * (capsuleWidth + spacing) + spacing) / 2
+
+                    for (index, level) in levelsToDraw.enumerated() {
+                        let safeLevel: CGFloat = min(max(CGFloat(level), 0.0), 1.0)
+
+                        let barHeight: CGFloat =
+                            safeLevel * (capsuleMaxHeight - capsuleMinHeight) + capsuleMinHeight
+
+                        let xPosition: CGFloat = startX + CGFloat(index) * (capsuleWidth + spacing)
+                        let yPosition: CGFloat = (size.height - barHeight) / 2
+
+                        let rect: CGRect = CGRect(
+                            x: xPosition,
+                            y: yPosition,
+                            width: capsuleWidth,
+                            height: barHeight
+                        )
+
+                        let path: Path = Path(roundedRect: rect, cornerRadius: capsuleWidth / 2)
+                        context.fill(path, with: .color(Color.black4))
+                    }
                 }
             }
+            .frame(height: capsuleMaxHeight)
+            .padding(.horizontal, Spacing.sm)
         }
 
-        private func clampHeight(_ height: CGFloat) -> CGFloat {
-            return min(90, max(10, height))
+        private func processLevels(count: Int) -> [Float] {
+            guard count > 0 else { return [] }
+
+            if audioLevels.count >= count {
+                return Array(audioLevels.suffix(count))
+            } else {
+                let paddingCount = count - audioLevels.count
+                return Array(repeating: 0.0, count: paddingCount) + audioLevels
+            }
         }
     }
 


### PR DESCRIPTION
### 설명

RecordingView Waveform이 화면 크기에 대응하도록 개선

### 관련 이슈

Closes #138

### 작업 내용

- [x] RecordingView Waveform이 화면 크기에 대응하도록 개선

### 스크린샷 (Optional)

왼쪽이 iPhone 17 Pro, 오른쪽이 iPhone 17 Pro Max입니다.

<p align="center">
  <img width="256" alt="iPhone 17 Pro" src="https://github.com/user-attachments/assets/94737d8e-870c-4ff4-bde0-15311eb7e7cb" />
  <img width="256" alt="iPhone 17 Pro Max" src="https://github.com/user-attachments/assets/7dc06dd1-1a9e-4eff-9786-5a41b067ea0a" />
</p>

### 참고 내용

기존 Capsule View로 구현한 Waveform을 렌더링 성능을 높이기 위해 Canvas로 구현하였습니다.