### PR TITLE
[fix] ChordProgressView에서 ChordCell 관련 버그 및 기능 수정

### DIFF
--- a/GMG/Core/Models/Score/ChordCell.swift
+++ b/GMG/Core/Models/Score/ChordCell.swift
@@ -30,3 +30,12 @@ extension ChordCell {
 extension ChordCell: Codable {}
 
 extension ChordCell: Hashable {}
+
+extension ChordCell: Equatable {
+    static func == (lhs: ChordCell, rhs: ChordCell) -> Bool {
+        lhs.chord == rhs.chord
+            && lhs.chordCandidates == rhs.chordCandidates
+            && lhs.startTime == rhs.startTime
+            && lhs.duration == rhs.duration
+    }
+}

--- a/GMG/Scenes/ChordProgress/ChordProgressIntent.swift
+++ b/GMG/Scenes/ChordProgress/ChordProgressIntent.swift
@@ -104,9 +104,7 @@ final class ChordProgressIntent: ChordProgressIntentProtocol {
             let chord = chordCell.chord
         else { return }
 
-        // 0초 시킹 시 Playhead가 변하지 않아 선택 상태 갱신이 스킵되는 것을 방지
-        let minSeekTime: TimeInterval = 0.001
-        scorePlayer.seek(to: max(seekTime, minSeekTime))
+        scorePlayer.seek(to: seekTime)
         scorePlayer.play(chord: chord)
         model.selectChordCell(chordCell)
     }

--- a/GMG/Scenes/ChordProgress/ChordProgressIntent.swift
+++ b/GMG/Scenes/ChordProgress/ChordProgressIntent.swift
@@ -12,7 +12,7 @@ protocol ChordProgressIntentProtocol {
     func onTapPauseButton()
     func onTapStopButton()
     func onTapMuteButton(_ isMuted: Bool)
-    func onTapChordCell(_ chordCell: ChordCell)
+    func onTapChordCell(_ chordCell: ChordCell, seekTime: TimeInterval)
     func onTapWaveform(_ time: TimeInterval)
     func onDragWaveformStart(_ time: TimeInterval)
     func onDragWaveformChange(_ time: TimeInterval)
@@ -98,11 +98,11 @@ final class ChordProgressIntent: ChordProgressIntentProtocol {
         self.scorePlayer?.setPlayerMuted(isMuted)
     }
 
-    func onTapChordCell(_ chordCell: ChordCell) {
+    func onTapChordCell(_ chordCell: ChordCell, seekTime: TimeInterval) {
         guard let scorePlayer = self.scorePlayer else { return }
         guard let model = self.model else { return }
 
-        scorePlayer.seek(chordCell: chordCell)
+        scorePlayer.seek(to: seekTime)
         model.selectChordCell(chordCell)
     }
 

--- a/GMG/Scenes/ChordProgress/ChordProgressIntent.swift
+++ b/GMG/Scenes/ChordProgress/ChordProgressIntent.swift
@@ -99,10 +99,15 @@ final class ChordProgressIntent: ChordProgressIntentProtocol {
     }
 
     func onTapChordCell(_ chordCell: ChordCell, seekTime: TimeInterval) {
-        guard let scorePlayer = self.scorePlayer else { return }
-        guard let model = self.model else { return }
+        guard let scorePlayer = self.scorePlayer,
+            let model = self.model,
+            let chord = chordCell.chord
+        else { return }
 
-        scorePlayer.seek(to: seekTime)
+        // 0초 시킹 시 Playhead가 변하지 않아 선택 상태 갱신이 스킵되는 것을 방지
+        let minSeekTime: TimeInterval = 0.001
+        scorePlayer.seek(to: max(seekTime, minSeekTime))
+        scorePlayer.play(chord: chord)
         model.selectChordCell(chordCell)
     }
 

--- a/GMG/Scenes/ChordProgress/ChordProgressModel.swift
+++ b/GMG/Scenes/ChordProgress/ChordProgressModel.swift
@@ -61,6 +61,11 @@ final class ChordProgressModel:
         self.canRedo = false
         self.segmentSlices = []
 
+        self.currentChordCell =
+            score
+            .retrieveCellIndexBy(time: playhead.elapsedTime)
+            .flatMap { score.retrieveChordCellBy(cellIndex: $0) }
+
         rebuildSegmentSlices()
     }
 
@@ -72,13 +77,10 @@ final class ChordProgressModel:
         if self.playhead != playhead {
             self.playhead = playhead
 
-            if let currentChordCellIndex: Int =
-                score.retrieveCellIndexBy(time: playhead.elapsedTime + 0.01),
-                let currentChordCell: ChordCell =
-                    score.retrieveChordCellBy(cellIndex: currentChordCellIndex)
-            {
-                self.currentChordCell = currentChordCell
-            }
+            self.currentChordCell =
+                score
+                .retrieveCellIndexBy(time: playhead.elapsedTime)
+                .flatMap { score.retrieveChordCellBy(cellIndex: $0) }
         }
     }
 

--- a/GMG/Scenes/ChordProgress/ChordProgressModel.swift
+++ b/GMG/Scenes/ChordProgress/ChordProgressModel.swift
@@ -44,27 +44,32 @@ final class ChordProgressModel:
     private(set) var isEditMode: Bool
     private(set) var playhead: Playhead
     private(set) var isMuted: Bool
-    private(set) var currentChordCell: ChordCell?
     private(set) var selectedChordCell: ChordCell?
     private(set) var canUndo: Bool
     private(set) var canRedo: Bool
     private(set) var segmentSlices: [[ChordSegmentSlice]]
+
+    var currentChordCell: ChordCell? {
+        guard
+            let currentChordCellIndex: Int =
+                score.retrieveCellIndexBy(time: playhead.elapsedTime + 0.01),
+            let currentChordCell: ChordCell =
+                score.retrieveChordCellBy(cellIndex: currentChordCellIndex)
+        else {
+            return nil
+        }
+        return currentChordCell
+    }
 
     init(score: Score) {
         self.score = score
         self.isEditMode = false
         self.playhead = Playhead(isPlaying: false, elapsedTime: .zero)
         self.isMuted = false
-        self.currentChordCell = nil
         self.selectedChordCell = nil
         self.canUndo = false
         self.canRedo = false
         self.segmentSlices = []
-
-        self.currentChordCell =
-            score
-            .retrieveCellIndexBy(time: playhead.elapsedTime)
-            .flatMap { score.retrieveChordCellBy(cellIndex: $0) }
 
         rebuildSegmentSlices()
     }
@@ -76,11 +81,6 @@ final class ChordProgressModel:
     func updatePlayhead(_ playhead: Playhead) {
         if self.playhead != playhead {
             self.playhead = playhead
-
-            self.currentChordCell =
-                score
-                .retrieveCellIndexBy(time: playhead.elapsedTime)
-                .flatMap { score.retrieveChordCellBy(cellIndex: $0) }
         }
     }
 

--- a/GMG/Scenes/ChordProgress/ChordProgressView.swift
+++ b/GMG/Scenes/ChordProgress/ChordProgressView.swift
@@ -57,17 +57,13 @@ struct ChordProgressView: View {
                     intent.onTapCandidateChordCell(chord, in: chordCell, for: model.score)
                 }
 
-                let onTapChordCell: (ChordCell, TimeInterval) -> Void = { chordCell, seekTime in
-                    intent.onTapChordCell(chordCell, seekTime: seekTime)
-                }
-
                 SegmentsScrollView(
                     totalDuration: model.score.totalDuration,
                     segmentSlices: model.segmentSlices,
                     currentChordCell: model.currentChordCell,
                     selectedChordCell: model.selectedChordCell,
                     segmentHandlers: SegmentHandlers(
-                        onTapChordCell: onTapChordCell,
+                        onTapChordCell: intent.onTapChordCell,
                         onTapChordCandidate: onTapChordCandidate
                     ),
                     waveformHandlers: WaveformHandlers(

--- a/GMG/Scenes/ChordProgress/ChordProgressView.swift
+++ b/GMG/Scenes/ChordProgress/ChordProgressView.swift
@@ -57,13 +57,17 @@ struct ChordProgressView: View {
                     intent.onTapCandidateChordCell(chord, in: chordCell, for: model.score)
                 }
 
+                let onTapChordCell: (ChordCell, TimeInterval) -> Void = { chordCell, seekTime in
+                    intent.onTapChordCell(chordCell, seekTime: seekTime)
+                }
+
                 SegmentsScrollView(
                     totalDuration: model.score.totalDuration,
                     segmentSlices: model.segmentSlices,
                     currentChordCell: model.currentChordCell,
                     selectedChordCell: model.selectedChordCell,
                     segmentHandlers: SegmentHandlers(
-                        onTapChordCell: intent.onTapChordCell,
+                        onTapChordCell: onTapChordCell,
                         onTapChordCandidate: onTapChordCandidate
                     ),
                     waveformHandlers: WaveformHandlers(

--- a/GMG/Scenes/ChordProgress/Segment.swift
+++ b/GMG/Scenes/ChordProgress/Segment.swift
@@ -79,10 +79,8 @@ struct Segment: View {
                                 chord: chord,
                                 isShowDescription: widthRatio
                                     >= Constants.minimumChordCellWidthRatio,
-                                isCurrentChord: currentChordCell?.startTime
-                                    == slice.chordCell.startTime,
-                                isSelected: selectedChordCell?.startTime
-                                    == slice.chordCell.startTime,
+                                isCurrentChord: currentChordCell == slice.chordCell,
+                                isSelected: selectedChordCell == slice.chordCell,
                                 onTapButton: {
                                     segmentHandlers.onTapChordCell(
                                         slice.chordCell,

--- a/GMG/Scenes/ChordProgress/Segment.swift
+++ b/GMG/Scenes/ChordProgress/Segment.swift
@@ -4,7 +4,7 @@ import Foundation
 import SwiftUI
 
 struct SegmentHandlers {
-    let onTapChordCell: (ChordCell) -> Void
+    let onTapChordCell: (ChordCell, TimeInterval) -> Void
     let onTapChordCandidate: (Chord, ChordCell) -> Void
 }
 
@@ -82,10 +82,14 @@ struct Segment: View {
                                 isCurrentChord: currentChordCell?.startTime
                                     == slice.chordCell.startTime,
                                 isSelected: selectedChordCell?.startTime
-                                    == slice.chordCell.startTime
-                            ) {
-                                segmentHandlers.onTapChordCell(slice.chordCell)
-                            }
+                                    == slice.chordCell.startTime,
+                                onTapButton: {
+                                    segmentHandlers.onTapChordCell(
+                                        slice.chordCell,
+                                        max(slice.chordCell.startTime, segmentStartTime)
+                                    )
+                                }
+                            )
                             .frame(width: cellWidth, height: 62)
                         } else {
                             Rectangle()
@@ -218,7 +222,7 @@ struct Segment: View {
         let isShowDescription: Bool
         let isCurrentChord: Bool
         let isSelected: Bool
-        let action: () -> Void
+        let onTapButton: () -> Void
 
         @Environment(\.editMode) private var editMode
 
@@ -260,7 +264,7 @@ struct Segment: View {
 
         var body: some View {
             Button {
-                action()
+                onTapButton()
             } label: {
                 ZStack {
                     if isShowDescription {


### PR DESCRIPTION
### 설명
처음 ChordProgressView에 들어왔을 때 맨 처음 ChordCell을 탭할 경우 탭이 되지 않는 버그를 수정합니다.
-  코드 셀 탭 시 시킹이 0초로 들어가면 Playhead가 변하지 않아 선택 상태가 스킵되는 문제를 막기 위해 seekTime을
    max(seekTime, 0.001)로 클램프하는 로직을 추가했습니다.

여러 세그먼트를 걸친 ChordCell을 탭할 때, 탭한 세그먼트의 ChordCell로 위치를 이동시킵니다.

### 관련 이슈

Closes #132 

### 작업 내용

- [x] 처음 chordCell Tap 동작 안하는 버그 수정
- [x] 여러 세그먼트를 걸친 ChordCell을 탭 기능 수정

