### PR TITLE
[bug] ChordSheetView에서 코드가 위에서부터 나오도록 수정

### DIFF
--- a/GMG/Scenes/Export/ChordSheetView.swift
+++ b/GMG/Scenes/Export/ChordSheetView.swift
@@ -50,7 +50,7 @@ struct ChordSheetView: View {
                         )
                     }
                 }
-                .frame(minHeight: 500)
+                .frame(minHeight: 500, alignment: .top)
 
                 LogoView()
                     .padding(.top, 30)


### PR DESCRIPTION
### 설명

ChordSheetView에서 코드가 위에서부터 나오도록 수정

### 관련 이슈

Closes #151

### 작업 내용

- [x] ChordSheetView에서 코드가 위에서부터 나오도록 수정

### 스크린샷 (Optional)

<p align="center">
  <img width="256" alt="ExportView" src="https://github.com/user-attachments/assets/bea61e77-181f-4ef5-a211-430751d13a09" />
</p>

### 참고 내용

