### PR TITLE
[bug] ChordSheetView에서 Zoom Navigation Transition 제스처가 웨이브폼과 겹치는 문제 수정

### DIFF
--- a/GMG/Core/Utils/PreviewContainer.swift
+++ b/GMG/Core/Utils/PreviewContainer.swift
@@ -26,7 +26,7 @@ struct PreviewContainer<Content: View>: View {
             content
                 .navigationDestination(for: RouteWrapper.self) { route in
                     router.view(route.route)
-                        .zoomTransition(id: route.id, in: route.namespace)
+                    //                        .zoomTransition(id: route.id, in: route.namespace)
                 }
         }
     }

--- a/GMG/Scenes/MainView.swift
+++ b/GMG/Scenes/MainView.swift
@@ -18,7 +18,7 @@ struct MainView: View {
             router.view(.home)
                 .navigationDestination(for: RouteWrapper.self) { route in
                     router.view(route.route)
-                        .zoomTransition(id: route.id, in: route.namespace)
+                    //                        .zoomTransition(id: route.id, in: route.namespace)
                 }
         }
     }


### PR DESCRIPTION
### 설명

ChordSheetView에서 Zoom Navigation Transition 제스처가 웨이브폼과 겹치는 문제 수정

### 관련 이슈

Closes #154

### 작업 내용

- [x] Zoom Navigation Transition 삭제

### 스크린샷 (Optional)



### 참고 내용

