### PR TITLE
[bug] ChordCandidate의 순서가 저장되지 않는 문제 수정

### DIFF
--- a/GMG/Core/Data/Repository/ScoreRepository.swift
+++ b/GMG/Core/Data/Repository/ScoreRepository.swift
@@ -123,10 +123,12 @@ extension ScoreSchema.Score {
             totalDuration: self.totalDuration,
             createdAt: self.createdAt,
             updatedAt: self.updatedAt,
-            notes: self.notes.map { $0.toDomain() }.sorted(by: { $0.startTime < $1.startTime }),
-            chordCells: self.chordCells.map { $0.toDomain() }.sorted(by: {
-                $0.startTime < $1.startTime
-            }),
+            notes: self.notes
+                .map { $0.toDomain() }
+                .sorted(by: { $0.startTime < $1.startTime }),
+            chordCells: self.chordCells
+                .map { $0.toDomain() }
+                .sorted(by: { $0.startTime < $1.startTime }),
             audioLevels: self.audioLevels,
             isDeleted: self.isDeleted
         )
@@ -282,7 +284,11 @@ extension ChordCell {
     fileprivate func toPersistence() -> ScoreSchema.ChordCell {
         return .init(
             chord: self.chord?.toPersistence(),
-            chordCandidates: self.chordCandidates.map { $0.toPersistence() },
+            chordCandidates: self.chordCandidates
+                .enumerated()
+                .map { index, chord in
+                    ScoreSchema.ChordCandidate(order: index, chord: chord.toPersistence())
+                },
             startTime: self.startTime,
             duration: self.duration
         )
@@ -293,7 +299,9 @@ extension ScoreSchema.ChordCell {
     fileprivate func toDomain() -> ChordCell {
         return .init(
             chord: self.chord?.toDomain(),
-            chordCandidates: self.chordCandidates.map { $0.toDomain() },
+            chordCandidates: self.chordCandidates
+                .sorted(by: { $0.order < $1.order })
+                .map { $0.chord.toDomain() },
             startTime: self.startTime,
             duration: self.duration
         )

--- a/GMG/Core/Data/Schema/ScoreSchemaV1.swift
+++ b/GMG/Core/Data/Schema/ScoreSchemaV1.swift
@@ -56,13 +56,13 @@ enum ScoreSchemaV1: VersionedSchema {
     @Model
     class ChordCell {
         @Relationship(deleteRule: .cascade) var chord: Chord? = nil
-        @Relationship(deleteRule: .cascade) var chordCandidates: [Chord] = []
+        @Relationship(deleteRule: .cascade) var chordCandidates: [ChordCandidate] = []
         var startTime: TimeInterval = TimeInterval.zero
         var duration: TimeInterval = TimeInterval.zero
 
         init(
             chord: Chord?,
-            chordCandidates: [Chord],
+            chordCandidates: [ChordCandidate],
             startTime: TimeInterval,
             duration: TimeInterval
         ) {
@@ -70,6 +70,20 @@ enum ScoreSchemaV1: VersionedSchema {
             self.chordCandidates = chordCandidates
             self.startTime = startTime
             self.duration = duration
+        }
+    }
+
+    @Model
+    class ChordCandidate {
+        var order: Int = 0
+        @Relationship(deleteRule: .cascade) var chord: Chord = Chord(root: .C, quality: .maj)
+
+        init(
+            order: Int,
+            chord: Chord
+        ) {
+            self.order = order
+            self.chord = chord
         }
     }
 


### PR DESCRIPTION
### 설명

ChordCandidate의 순서가 저장되지 않는 문제 수정

### 관련 이슈

Closes #160

### 작업 내용

- [x] SwiftData에 저장할 때 순서를 함께 저장하도록 변경

### 스크린샷 (Optional)



### 참고 내용

이전 저장된 데이터는 코드 후보 데이터 사용이 불가능합니다.