### PR TITLE
[bug] 특정 조건에서 코드 후보 셀이 열리지 않는 버그 수정

### DIFF
--- a/GMG/Core/Models/Score/Score.swift
+++ b/GMG/Core/Models/Score/Score.swift
@@ -182,7 +182,7 @@ extension Score {
                         Chord(root: .Eb, quality: .maj),
                     ],
                     startTime: 5.0,
-                    duration: 6.3
+                    duration: 4.8
                 ),
                 ChordCell(
                     chord: Chord(root: .F, quality: .maj9),
@@ -193,8 +193,8 @@ extension Score {
                         Chord(root: .Gb, quality: .maj),
                         Chord(root: .Eb, quality: .maj),
                     ],
-                    startTime: 11.3,
-                    duration: 1.7
+                    startTime: 9.9,
+                    duration: 0.8
                 ),
                 ChordCell(
                     chord: Chord(root: .Bb, quality: .maj),
@@ -205,7 +205,7 @@ extension Score {
                         Chord(root: .Gb, quality: .maj),
                         Chord(root: .Eb, quality: .maj),
                     ],
-                    startTime: 13.0,
+                    startTime: 10.7,
                     duration: 18.0
                 ),
             ],

--- a/GMG/Scenes/ChordProgress/Segment.swift
+++ b/GMG/Scenes/ChordProgress/Segment.swift
@@ -104,7 +104,6 @@ struct Segment: View {
                 && chordSlices.contains(where: {
                     $0.chordCell.startTime == selectedChordCell?.startTime
                 })
-                && selectedChordCell?.startTime ?? 0.0 >= segmentStartTime
 
             ChordCellCandidates(
                 chordCell: selectedChordCell ?? ChordCell.empty,


### PR DESCRIPTION
## 설명
코드 후보 셀이 가끔 열리지 않는 버그를 수정했습니다.

### 버그 발생 조건
- 하나의 코드 셀이 두 개의 세그먼트에 걸쳐 있을 때 발생하는 문제입니다.
- 첫 번째 세그먼트에서는 코드 셀이 노출 조건을 만족하지 않고,  
  두 번째 세그먼트에서만 코드 셀이 노출되는 경우  
  해당 코드 셀을 선택해도 **코드 후보 셀이 열리지 않는 현상**이 발생했습니다.

### 해결 방법
- 코드 셀을 클릭하면, 해당 코드 셀을 포함하고 있는 **모든 세그먼트에서 코드 후보 셀이 열리도록**  
  디자인 및 기능을 수정했습니다. ps) 이 방식이 UX적으로 동작을 이해하기 쉽고, 전체 흐름의 가독성도 더 좋다고 판단했습니다.

* 해당 디자인은 아직 논의되지 않은 부분이니까 편하게 리뷰주세요~

## 관련 이슈

Closes #159 

## 작업 내용
- [x] 특정 조건에서 코드 후보 셀이 열리지 버그 수정

## 스크린샷 (Optional)
<img width="215" height="410" alt="image" src="https://github.com/user-attachments/assets/a2b60b66-7515-4c31-a63b-f89dfbcda734" />

