### PR TITLE
[bug] 재생 중 악기 변경 시 앱이 강제 종료되는 문제 수정

### DIFF
--- a/GMG/Core/Models/ScorePlayer/ScorePlayer.swift
+++ b/GMG/Core/Models/ScorePlayer/ScorePlayer.swift
@@ -68,7 +68,7 @@ final class DefaultScorePlayer: ScoreAudioEngineBase, ScorePlayer {
 
         // 코드 재생 준비
         try loadSoundBank(instrument: currentInstrumentPublisher.value)
-        prepareChordCells(octave: currentInstrumentPublisher.value.octave)
+        prepareChordCells()
 
         // 타이머 설정
         Timer.publish(
@@ -93,30 +93,32 @@ final class DefaultScorePlayer: ScoreAudioEngineBase, ScorePlayer {
         }
         .store(in: &cancellables)
 
-        NotificationCenter.default.publisher(for: AVAudioSession.routeChangeNotification)
-            .sink { [weak self] notification in
-                guard let self else { return }
+        NotificationCenter.default.publisher(
+            for: AVAudioSession.routeChangeNotification
+        )
+        .sink { [weak self] notification in
+            guard let self else { return }
 
-                do {
-                    let wasPlaying = self.player.isPlaying
-                    self.pause()
+            do {
+                let wasPlaying = self.player.isPlaying
+                self.pause()
 
-                    try self.activateAudioSession()
-                    try self.engine.start()
+                try self.activateAudioSession()
+                try self.engine.start()
 
-                    Task {
-                        try? await Task.sleep(for: .seconds(0.1))
-                        try? self.loadSoundBank()
+                Task {
+                    try? await Task.sleep(for: .seconds(0.1))
+                    try? self.loadSoundBank()
 
-                        if wasPlaying {
-                            self.play()
-                        }
+                    if wasPlaying {
+                        self.play()
                     }
-                } catch {
-                    Logger.error(String(describing: error))
                 }
+            } catch {
+                Logger.error(String(describing: error))
             }
-            .store(in: &cancellables)
+        }
+        .store(in: &cancellables)
     }
 
     func cleanupAfterPlay() {
@@ -238,9 +240,7 @@ final class DefaultScorePlayer: ScoreAudioEngineBase, ScorePlayer {
         do {
             try loadSoundBank(instrument: instrument)
 
-            super.prepareChordCells(octave: instrument.octave)
-
-            pause()
+            prepareChordCells()
 
             self.currentInstrumentPublisher.send(instrument)
         } catch {
@@ -249,9 +249,17 @@ final class DefaultScorePlayer: ScoreAudioEngineBase, ScorePlayer {
     }
 
     func prepareChordCells() {
+        let wasPlaying = player.isPlaying
+
+        pause()
+
         super.prepareChordCells(
             octave: currentInstrumentPublisher.value.octave
         )
+
+        if wasPlaying {
+            play()
+        }
     }
 
     private func activateAudioSession() throws {


### PR DESCRIPTION
### 설명

재생 중 악기 변경 시 앱이 강제 종료되는 문제 수정

### 관련 이슈

Closes #166

### 작업 내용

- [x] `prepareChordCells` 메서드에 일시 정지 후 시퀀스 트랙을 재생성하도록 수정

### 스크린샷 (Optional)



### 참고 내용

재생 중에 악기를 변경하거나 Undo, Redo로 코드를 바꿀 때 Sequencer의 Track을 제거하려고 하면 강제 종료되어서 반드시 일시 정지하도록 수정했습니다.